### PR TITLE
fix: Show provider fields even when empty

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/cdk": ">=19.0.0",
+    "@angular/cdk": "^19.0.0",
     "@angular/common": "^19.2.0",
     "@angular/compiler": "^19.2.0",
     "@angular/core": "^19.2.0",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
   .:
     dependencies:
       '@angular/cdk':
-        specifier: '>=19.0.0'
+        specifier: ^19.0.0
         version: 19.2.7(@angular/common@19.2.3(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.3(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2)
       '@angular/common':
         specifier: ^19.2.0

--- a/client/src/app/components/providers/providers.component.html
+++ b/client/src/app/components/providers/providers.component.html
@@ -4,19 +4,12 @@
       <h1 class="text-4xl text-neutral-200 font-bold">Providers</h1>
     </div>
   </div>
-  <div
-    *ngIf="providers.length > 0"
-    class="grid grid-cols-1 lg:grid-cols-2 gap-8"
-  >
-    <app-provider [Provider]="getProvider('openai')"></app-provider>
-
-    <app-provider [Provider]="getProvider('anthropic')"></app-provider>
-
-    <app-provider [Provider]="getProvider('gemini')"></app-provider>
-
-    <app-provider [Provider]="getProvider('voyage')"></app-provider>
-
-    <app-provider [Provider]="getProvider('qdrant')"></app-provider>
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <app-provider [Provider]="providerMap['openai']"></app-provider>
+    <app-provider [Provider]="providerMap['anthropic']"></app-provider>
+    <app-provider [Provider]="providerMap['gemini']"></app-provider>
+    <app-provider [Provider]="providerMap['voyage']"></app-provider>
+    <app-provider [Provider]="providerMap['qdrant']"></app-provider>
   </div>
 </div>
 

--- a/client/src/app/components/providers/providers.component.ts
+++ b/client/src/app/components/providers/providers.component.ts
@@ -16,22 +16,30 @@ import { ProviderComponent } from 'src/app/shared/components/provider/provider.c
 })
 export class ProvidersComponent implements OnInit {
   providers: GetProvidersResponse = [];
+
+  providerMap: Record<SupportedProvider, Provider> = {
+    openai: this.getDefaultProvider('openai'),
+    anthropic: this.getDefaultProvider('anthropic'),
+    gemini: this.getDefaultProvider('gemini'),
+    voyage: this.getDefaultProvider('voyage'),
+    qdrant: this.getDefaultProvider('qdrant'),
+  };
+
   constructor(private providersService: ProvidersService) {}
 
   ngOnInit(): void {
     this.getUserProviders();
   }
 
-  getProvider(provider: string): Provider {
-    if (!this.providers || this.providers.length === 0) {
-      return this.getDefaultProvider(provider);
-    }
+  getUserProviders() {
+    this.providersService.getUserProviders().subscribe((response) => {
+      this.providers = response;
 
-    const prov = this.providers.find(
-      (prov) => prov.provider.toLowerCase() === provider.toLowerCase()
-    );
-
-    return prov ?? this.getDefaultProvider(provider);
+      for (const p of response) {
+        const key = p.provider.toLowerCase() as SupportedProvider;
+        this.providerMap[key] = p;
+      }
+    });
   }
 
   getDefaultProvider(provider: string): Provider {
@@ -41,11 +49,5 @@ export class ProvidersComponent implements OnInit {
       userId: '',
       provider: provider as SupportedProvider,
     };
-  }
-
-  getUserProviders() {
-    this.providersService.getUserProviders().subscribe((response) => {
-      this.providers = response;
-    });
   }
 }

--- a/client/src/app/core/constants/providers.constant.ts
+++ b/client/src/app/core/constants/providers.constant.ts
@@ -29,7 +29,7 @@ export const PROVIDERS_DATA: Record<SupportedProvider, ProviderData> = {
     icon: 'img/providers/voyage.svg',
     apiKeyUrl: 'https://voyage.ai/account/settings',
     keyTemplate: 'pa-***************',
-    regex: '^pa-[A-Za-z0-9-]{30,60}$',
+    regex: '^pa-[A-Za-z0-9-_]{30,60}$',
   },
   qdrant: {
     id: 3,

--- a/client/src/app/shared/components/provider/provider.component.ts
+++ b/client/src/app/shared/components/provider/provider.component.ts
@@ -1,6 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
-import { InputComponent } from '../input/input.component';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 import {
   FormBuilder,
   FormGroup,
@@ -49,7 +54,7 @@ import {
   ],
   standalone: true,
 })
-export class ProviderComponent implements OnInit {
+export class ProviderComponent implements OnInit, OnChanges {
   @Input() Provider!: Provider;
 
   providerId = '';
@@ -65,7 +70,19 @@ export class ProviderComponent implements OnInit {
     private providersService: ProvidersService
   ) {}
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['Provider'] && changes['Provider'].currentValue) {
+      this.initializeProvider();
+    }
+  }
+
   ngOnInit() {
+    this.initializeProvider();
+  }
+
+  initializeProvider() {
+    if (!this.Provider) return;
+
     this.form = this.fb.group({
       apiKey: ['', Validators.required],
     });
@@ -76,13 +93,11 @@ export class ProviderComponent implements OnInit {
 
     this.hasApiKey = !!this.Provider.apiKey;
     this.providerId = this.Provider?.id;
+
     if (this.Provider.apiKey && this.providerData?.keyTemplate) {
-      const visibleKey = this.providerData?.keyTemplate + this.Provider.apiKey;
-
+      const visibleKey = this.providerData.keyTemplate + this.Provider.apiKey;
       this.lastValidValue = visibleKey;
-
       this.form.patchValue({ apiKey: visibleKey });
-
       this.disableInput();
     }
 

--- a/client/src/main.server.ts
+++ b/client/src/main.server.ts
@@ -2,6 +2,13 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { config } from './app/app.config.server';
 
+import { environment } from './environments/environment';
+import { enableProdMode } from '@angular/core';
+
+if ((environment as any).production) {
+  enableProdMode();
+}
+
 const bootstrap = () => bootstrapApplication(AppComponent, config);
 
 export default bootstrap;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,5 +2,12 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, appConfig)
-  .catch((err) => console.error(err));
+import { environment } from './environments/environment';
+import { enableProdMode } from '@angular/core';
+
+if ((environment as any).production) {
+  enableProdMode();
+}
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);


### PR DESCRIPTION
## Changes
- Modified provider fields visibility logic to always show fields regardless of their completion status
- Previously, provider fields were hidden when no data was entered
- Now fields are visible by default, providing better UX and clearer input requirements

## Testing
- Verified that all provider fields are now visible in empty state
- Confirmed existing populated fields continue to work as expected